### PR TITLE
Simplify build

### DIFF
--- a/build.fsx
+++ b/build.fsx
@@ -170,7 +170,7 @@ let execNPX args =
     Process.execSimple
         (fun info ->
             { info with
-                FileName = "npx"
+                FileName = "C:/Users/selketjah/AppData/Local/Yarn/bin/npx.cmd"
                 Arguments = args
             }
         )
@@ -189,7 +189,8 @@ let execNPXNoTimeout args =
     |> ignore
 
 let buildSass _ =
-    execNPX "node-sass --output-style compressed --output docs/public/ docs/scss/main.scss"
+    Yarn.exec "run npx node-sass --output-style compressed --output docs/public/ docs/scss/main.scss" id
+    //execNPX "node-sass --output-style compressed --output docs/public/ docs/scss/main.scss"
 
 let applyAutoPrefixer _ =
     execNPX " postcss docs/public/main.css --use autoprefixer -o docs/public/main.css"

--- a/build.fsx
+++ b/build.fsx
@@ -73,10 +73,6 @@ let run (cmd:string) dir args  =
     ) TimeSpan.MaxValue <> 0 then
         failwithf "Error while running '%s' with args: %s " cmd args
 
-let yarnTool = platformTool "yarn"
-
-let yarn = run yarnTool "./"
-
 let mono workingDir args =
     let code =
         Process.execSimple
@@ -143,7 +139,6 @@ Target.create "MochaTest" (fun _ ->
         //Run mocha tests
         let projDirOutput = projDir </> "bin"
         Yarn.exec ("run mocha " + projDirOutput) id
-        //yarn ("run mocha " + projDirOutput)
     )
 )
 

--- a/build.fsx
+++ b/build.fsx
@@ -142,7 +142,8 @@ Target.create "MochaTest" (fun _ ->
 
         //Run mocha tests
         let projDirOutput = projDir </> "bin"
-        yarn ("run mocha " + projDirOutput)
+        Yarn.exec ("run mocha " + projDirOutput) id
+        //yarn ("run mocha " + projDirOutput)
     )
 )
 
@@ -166,27 +167,16 @@ let docs = root </> "docs"
 let docsContent = docs </> "src" </> "Content"
 let buildMain = docs </> "build" </> "src" </> "Main.js"
 
-let execNPX args =
-    Process.execSimple
-        (fun info ->
-            { info with
-                FileName = "C:/Users/selketjah/AppData/Local/Yarn/bin/npx.cmd"
-                Arguments = args
-            }
-        )
-        (TimeSpan.FromSeconds 30.)
-    |> ignore
-
-let execNPXNoTimeout args =
-    Process.execSimple
-        (fun info ->
-            { info with
-                FileName = "npx"
-                Arguments = args
-            }
-        )
-        (TimeSpan.FromHours 2.)
-    |> ignore
+// let execNPXNoTimeout args =
+//     Process.execSimple
+//         (fun info ->
+//             { info with
+//                 FileName = "npx"
+//                 Arguments = args
+//             }
+//         )
+//         (TimeSpan.FromHours 2.)
+//     |> ignore
 
 let buildSass _ =
     Yarn.exec "run npx node-sass --output-style compressed --output docs/public/ docs/scss/main.scss" id
@@ -221,7 +211,8 @@ Target.create "Docs.Watch" (fun _ ->
             dotnet projDir "fable" "yarn-run fable-splitter --port free -- -c docs/splitter.config.js -w"
           }
           async {
-            execNPXNoTimeout "node-sass --output-style compressed --watch --output docs/public/ docs/scss/main.scss"
+            Yarn.exec "run npx node-sass --output-style compressed --watch --output docs/public/ docs/scss/main.scss" id
+            //execNPXNoTimeout "node-sass --output-style compressed --watch --output docs/public/ docs/scss/main.scss"
           }
         ]
         |> Async.Parallel

--- a/build.fsx
+++ b/build.fsx
@@ -190,10 +190,9 @@ let execNPXNoTimeout args =
 
 let buildSass _ =
     Yarn.exec "run npx node-sass --output-style compressed --output docs/public/ docs/scss/main.scss" id
-    //execNPX "node-sass --output-style compressed --output docs/public/ docs/scss/main.scss"
 
 let applyAutoPrefixer _ =
-    execNPX " postcss docs/public/main.css --use autoprefixer -o docs/public/main.css"
+    Yarn.exec "run npx postcss docs/public/main.css --use autoprefixer -o docs/public/main.css" id
 
 Target.create "Docs.Watch" (fun _ ->
     use watcher = new FileSystemWatcher(docsContent, "*.md")


### PR DESCRIPTION
- replace manual "yarn run ..." with Yarn.exec
- replace executeNPX with Yarn.exec
- replace execNPXNoTimeout with Yarn.exec

=> when I do "./fake.sh build -t Docs.Watch" and exist it, I get a failure for npx (even though node-sass is executed and shows the correct behavior). This use to use the execNPXNoTimeout method, which shows the same failure message. Either way I left the code in comment for now in the file due to this failure, in case it needs to be reverted...