### PR TITLE
Change Decode.option implementation

### DIFF
--- a/src/Thoth.Json/Decode.fs
+++ b/src/Thoth.Json/Decode.fs
@@ -277,9 +277,11 @@ let keyValuePairs (decoder : Decoder<'value>) : Decoder<(string * 'value) list> 
 
 let option (d1 : Decoder<'value>) : Decoder<'value option> =
     fun value ->
-        match decodeValue d1 value with
-        | Ok v -> Ok (Some v)
-        | Error _ -> Ok None
+        // Fable uses non-strict equality for null checking so this will work with
+        // undefined too, but we may need a helper in case Fable implementation changes
+        if isNull value
+        then Ok None
+        else d1 value |> Result.map Some
 
 let oneOf (decoders : Decoder<'value> list) : Decoder<'value> =
     fun value ->


### PR DESCRIPTION
Not sure if this is an error or if it's intended, right now it will swallow any error when decoding the value and will output `None` instead. But I guess most users will expect this to fail if you get a different type (say, "foo" instead of an int) and only output `None` if the JSON value is `null/undefined`.

If the current behaviour is intended I would change the name (e.g. `tryDecode`) and/or add a document comment to explain what this function really does.