### PR TITLE
add object decoder

### DIFF
--- a/tests/Tests.Json.Decode.fs
+++ b/tests/Tests.Json.Decode.fs
@@ -222,6 +222,165 @@ let tests : Test =
                 equal expected actual
         ]
 
+        testList "object decoder" [
+
+            testCase "field.Required works" <| fun _ ->
+                let json = """{ "name": "maxime", "age": 25 }"""
+                let expected = Ok("maxime")
+
+                let actual =
+                    decodeString (object <| fun { field = field } -> field.Required "name" string) json
+
+                equal expected actual
+
+            testCase "field.Required returns error if field is missing" <| fun _ ->
+                let json = """{ "name": "maxime", "age": 25 }"""
+                let expected =
+                    Error(
+                        """
+Expecting an object with a field named `height` but instead got:
+{
+    "name": "maxime",
+    "age": 25
+}
+                        """.Trim())
+
+                let actual =
+                    decodeString (object <| fun { field = field } -> field.Required "height" string) json
+
+                equal expected actual
+
+            testCase "field.Required returns Error if type is incorrect" <| fun _ ->
+                let json = """{ "name": "maxime", "age": 25 }"""
+                let expected = Error("""Expecting an int but instead got: "maxime" """.Trim())
+
+                let actual =
+                    decodeString (object <| fun { field = field } -> field.Required "name" int) json
+
+                equal expected actual
+
+
+            testCase "field.Optional works" <| fun _ ->
+                let json = """{ "name": "maxime", "age": 25 }"""
+                let expected = Ok (Some "maxime")
+
+                let actual =
+                    decodeString (object <| fun { field = field } -> field.Optional "name" string) json
+
+                equal expected actual
+
+            testCase "field.Optional returns Ok None if field is missing" <| fun _ ->
+                let json = """{ "name": "maxime", "age": 25 }"""
+                let expected = Ok None
+
+                let actual =
+                    decodeString (object <| fun { field = field } -> field.Optional "height" string) json
+
+                equal expected actual
+
+            testCase "field.Optional returns Error if type is incorrect" <| fun _ ->
+                let json = """{ "name": "maxime", "age": 25 }"""
+                let expected = Error("""Expecting an int but instead got: "maxime" """.Trim())
+
+                let actual =
+                    decodeString (object <| fun { field = field } -> field.Optional "name" int) json
+
+                equal expected actual
+
+
+            testCase "at.Required works" <| fun _ ->
+
+                let json = """{ "user": { "name": "maxime", "age": 25 } }"""
+                let expected = Ok "maxime"
+
+                let actual =
+                    decodeString (object <| fun { at = at } -> at.Required ["user"; "name"] string) json
+
+                equal expected actual
+
+            testCase "at.Required returns Error if non-object in path" <| fun _ ->
+                let json = """{ "user": "maxime" }"""
+                let expected =
+                    Error(
+                        """
+Expecting an object at `user` but instead got:
+"maxime"
+                        """.Trim())
+
+                let actual =
+                    decodeString (object <| fun { at = at } -> at.Required ["user"; "name"] string) json
+
+                equal expected actual
+
+            testCase "at.Required returns Error if field missing" <| fun _ ->
+                let json = """{ "user": { "name": "maxime", "age": 25 } }"""
+                let expected =
+                    Error(
+                        """
+Expecting an object with path `user.firstname` but instead got:
+{
+    "user": {
+        "name": "maxime",
+        "age": 25
+    }
+}
+Node `firstname` is unkown.
+                        """.Trim())
+
+                let actual =
+                    decodeString (object <| fun { at = at } -> at.Required ["user"; "firstname"] string) json
+
+                equal expected actual
+
+            testCase "at.Required returns Error if type is incorrect" <| fun _ ->
+                let json = """{ "user": { "name": "maxime", "age": 25 } }"""
+                let expected = Error("""Expecting an int but instead got: "maxime" """.Trim())
+
+                let actual =
+                    decodeString (object <| fun { at = at } -> at.Required ["user"; "name"] int) json
+
+                equal expected actual
+
+
+            testCase "at.Optional works" <| fun _ ->
+
+                let json = """{ "user": { "name": "maxime", "age": 25 } }"""
+                let expected = Ok (Some "maxime")
+
+                let actual =
+                    decodeString (object <| fun { at = at } -> at.Optional ["user"; "name"] string) json
+
+                equal expected actual
+
+            testCase "at.Optional returns Ok None if non-object in path" <| fun _ ->
+                let json = """{ "user": "maxime" }"""
+                let expected = Ok None
+
+                let actual =
+                    decodeString (object <| fun { at = at } -> at.Optional ["user"; "name"] string) json
+
+                equal expected actual
+
+            testCase "at.Optional returns Ok None if field missing" <| fun _ ->
+                let json = """{ "user": { "name": "maxime", "age": 25 } }"""
+                let expected = Ok None
+
+                let actual =
+                    decodeString (object <| fun { at = at } -> at.Optional ["user"; "firstname"] string) json
+
+                equal expected actual
+
+            testCase "at.Optional returns Error if type is incorrect" <| fun _ ->
+                let json = """{ "user": { "name": "maxime", "age": 25 } }"""
+                let expected = Error("""Expecting an int but instead got: "maxime" """.Trim())
+
+                let actual =
+                    decodeString (object <| fun { at = at } -> at.Optional ["user"; "name"] int) json
+
+                equal expected actual
+
+        ]
+
         testList "Object primitives" [
 
             testCase "field works" <| fun _ ->

--- a/tests/Tests.Json.Decode.fs
+++ b/tests/Tests.Json.Decode.fs
@@ -439,6 +439,20 @@ Node `firstname` is unkown.
 
                 equal expected actual
 
+            testCase "at output an error if non-object in path" <| fun _ ->
+                let json = """{ "user": "maxime" }"""
+                let expected =
+                    Error(
+                        """
+Expecting an object at `user` but instead got:
+"maxime"
+                        """.Trim())
+
+                let actual =
+                    decodeString (at ["user"; "firstname"] string) json
+
+                equal expected actual
+
             testCase "index works" <| fun _ ->
                 let json = """["maxime", "alfonso", "steffen"]"""
                 let expected = Ok("alfonso")


### PR DESCRIPTION
This should be considered more of a proposal than a complete and mergable implementation, mostly because the ergonomics isn't as good as I hope it can be, but it could also use some refactoring and clean-up. As it is, I've mostly tried to emulate the behavior of the existing `field` and `at` decoders, which is a bit awkward with this approach.

There are several reasons for this proposal:
* Using `map` and the "pipeline" to decode objects is error-prone as it relies on disassociated positional arguments. So if you order the arguments wrong, you lose.
* `field` and `at` mixes several concerns. It does not properly separate the validation of the object with that of the field. Even if you can pattern match on the different kinds of errors, combinators like `option` don't do that, and it's not clear how you'd tweak that API to do so without becoming very verbose.

The only major downside I've found is that you can't use the existing decoder combinators, such as `optional` and `either`. You can use `field.optional` with `Option.orElse`, for example, though unfortunately that doesn't seem to exist in F# yet.

Here's an example of how it currently looks in use:

```fsharp
object <| fun { field = field; at = at } -> {
  name = field.required "name" string;
  posX = at.required ["pos"; "x"] float;
  posY = at.required ["pos"; "x"] float;
  height = field.optional "height" int
}
```

Also note that this is an idea that originates from a bit of experimentation I'm doing on [my Reason/BuckleScript JSON library](https://github.com/glennsl/bs-json). And if some good ideas pop up here, I'll most likely steal it ;)