### PR TITLE
Relax dependency on Newtonsoft.Json

### DIFF
--- a/paket.dependencies
+++ b/paket.dependencies
@@ -2,8 +2,8 @@ source https://www.nuget.org/api/v2
 
 storage:none
 
-clitool dotnet-fable 2.0.0-alpha-029
-nuget Fable.Core 2.0.0-alpha-011
+clitool dotnet-fable >= 2.0.0-alpha-029
+nuget Fable.Core >= 2.0.0-alpha-011
 nuget FSharp.Core redirects:force
 nuget Fable.Import.Browser
 nuget Newtonsoft.Json >= 11.0.2

--- a/paket.dependencies
+++ b/paket.dependencies
@@ -6,7 +6,7 @@ clitool dotnet-fable 2.0.0-alpha-029
 nuget Fable.Core 2.0.0-alpha-011
 nuget FSharp.Core redirects:force
 nuget Fable.Import.Browser
-nuget Newtonsoft.Json 11.0.2
+nuget Newtonsoft.Json >= 11.0.2
 nuget Expecto
 nuget Fable.Elmish
 nuget Fable.PowerPack
@@ -67,4 +67,4 @@ group Demos
     nuget Fulma
     nuget Thoth.Elmish
     nuget Fulma.Extensions prerelease
-nuget Fable.Import.HMR
+    nuget Fable.Import.HMR


### PR DESCRIPTION
I think this won't affect the Nuget package, because Nuget doesn't allow pinned dependencies. But it's a problem when using Thoth as a Github dependency with Paket.