### PR TITLE
Fix decoding of optional fields

### DIFF
--- a/src/Thoth.Json.Net/Decode.fs
+++ b/src/Thoth.Json.Net/Decode.fs
@@ -376,9 +376,12 @@ module Decode =
             else
                 // TODO: Review, is this OK?
                 match d1 path value with
-                | Ok v -> Some v |> Ok
-                | Error(_, (BadField _)) -> Ok None
-                | Error er -> Error er
+                | Ok v -> Ok (Some v)
+                | Error (_, BadField _ ) -> Ok None
+                | Error (_, BadType (_, jToken))
+                | Error (_, BadPrimitive (_, jToken)) when jToken.Type = JTokenType.Null -> Ok None
+                | Error error -> Error error
+
 
     let oneOf (decoders : Decoder<'value> list) : Decoder<'value> =
         fun path value ->

--- a/src/Thoth.Json/Decode.fs
+++ b/src/Thoth.Json/Decode.fs
@@ -399,9 +399,12 @@ module Decode =
             else
                 // TODO: Review, is this OK?
                 match d1 path value with
-                | Ok v -> Some v |> Ok
-                | Error(_, (BadField _)) -> Ok None
-                | Error er -> Error er
+                | Ok v -> Ok (Some v)
+                | Error (_, BadField _ )
+                | Error (_, BadType (_, null))
+                | Error (_, BadPrimitive (_, null)) -> Ok None
+                | Error error -> Error error
+
 
     let oneOf (decoders : Decoder<'value> list) : Decoder<'value> =
         fun path value ->

--- a/tests/Tests.Json.Decode.fs
+++ b/tests/Tests.Json.Decode.fs
@@ -933,7 +933,7 @@ Expecting an object but instead got:
                 equal expected actual
 
             testCase "optional works" <| fun _ ->
-                let json = """{ "name": "maxime", "age": 25 }"""
+                let json = """{ "name": "maxime", "age": 25, "something_undefined": null }"""
 
                 let expectedValid = Ok(Some "maxime")
                 let actualValid =
@@ -951,6 +951,11 @@ Expecting an object but instead got:
 
                 equal expectedMissingField actualMissingField
 
+                let expectedUndefinedField = Ok(None)
+                let actualUndefinedField =
+                    Decode.fromString (Decode.option (Decode.field "something_undefined" Decode.string) ) json
+
+                equal expectedUndefinedField actualUndefinedField
         ]
 
         testList "Fancy decoding" [


### PR DESCRIPTION
The time has come to review that part of code. I've just copy-pasted logic from builder to `Decode.option`, but I think `| Error (_, BadType (_, jToken))` part should be removed both from builder and `Decode.option`.