### PR TITLE
[WIP - DO NOT MERGE] Fix encoding of unions/records with private constructors in .NET

### DIFF
--- a/src/Thoth.Json.Net/Decode.fs
+++ b/src/Thoth.Json.Net/Decode.fs
@@ -825,7 +825,6 @@ module Decode =
     // Reflection ///
     ////////////////
 
-    open System.Reflection
     open FSharp.Reflection
 
     type FieldType =
@@ -958,22 +957,22 @@ module Decode =
                         System.Activator.CreateInstance(mapType, kvs) |> Ok
 
     and private makeUnion t isCamelCase name (path : string) (values: JToken[]) =
-        // The flags are necessary for unions or records with private constructors
-        match FSharpType.GetUnionCases(t, BindingFlags.Public ||| BindingFlags.NonPublic) |> Array.tryFind (fun x -> x.Name = name) with
+        // The flag is necessary for unions or records with private constructors
+        match FSharpType.GetUnionCases(t, allowAccessToPrivateRepresentation=true) |> Array.tryFind (fun x -> x.Name = name) with
         | None -> (path, FailMessage("Cannot find case " + name + " in " + t.FullName)) |> Error
         | Some uci ->
             if values.Length = 0 then
-                FSharpValue.MakeUnion(uci, [||], BindingFlags.Public ||| BindingFlags.NonPublic) |> Ok
+                FSharpValue.MakeUnion(uci, [||], allowAccessToPrivateRepresentation=true) |> Ok
             else
                 let decoders = uci.GetFields() |> Array.map (fun fi -> autoDecoder isCamelCase false fi.PropertyType)
                 mixedArray "union fields" decoders path values
-                |> Result.map (fun values -> FSharpValue.MakeUnion(uci, List.toArray values, BindingFlags.Public ||| BindingFlags.NonPublic))
+                |> Result.map (fun values -> FSharpValue.MakeUnion(uci, List.toArray values, allowAccessToPrivateRepresentation=true))
 
     and private autoDecodeRecordsAndUnions (t: System.Type) (isCamelCase : bool) (isOptional : bool) : BoxedDecoder =
-        if FSharpType.IsRecord(t, BindingFlags.Public ||| BindingFlags.NonPublic) then
+        if FSharpType.IsRecord(t, allowAccessToPrivateRepresentation=true) then
             boxDecoder(fun path value ->
                 let decoders =
-                    FSharpType.GetRecordFields(t, BindingFlags.Public ||| BindingFlags.NonPublic)
+                    FSharpType.GetRecordFields(t, allowAccessToPrivateRepresentation=true)
                     |> Array.map (fun fi ->
                         let name =
                             if isCamelCase then
@@ -993,9 +992,9 @@ module Decode =
 
                         fieldType, name, autoDecoder isCamelCase fieldType.ToBool propertyType)
                 autoObject decoders path value
-                |> Result.map (fun xs -> FSharpValue.MakeRecord(t, List.toArray xs, BindingFlags.Public ||| BindingFlags.NonPublic)))
+                |> Result.map (fun xs -> FSharpValue.MakeRecord(t, List.toArray xs, allowAccessToPrivateRepresentation=true)))
 
-        elif FSharpType.IsUnion(t, BindingFlags.Public ||| BindingFlags.NonPublic) then
+        elif FSharpType.IsUnion(t, allowAccessToPrivateRepresentation=true) then
             boxDecoder(fun path (value: JToken) ->
                 if Helpers.isString(value) then
                     let name = Helpers.asString value

--- a/src/Thoth.Json.Net/Encode.fs
+++ b/src/Thoth.Json.Net/Encode.fs
@@ -302,7 +302,7 @@ module Encode =
     type Auto =
         static member toString(space : int, value : obj, ?forceCamelCase : bool) : string =
             let format = if space = 0 then Formatting.None else Formatting.Indented
-            let settings = JsonSerializerSettings(Converters = [|Converters.CacheConverter.Singleton|],
+            let settings = JsonSerializerSettings(Converters = Converters.All,
                                                   Formatting = format)
 
             if defaultArg forceCamelCase false then

--- a/src/Thoth.Json/Decode.fs
+++ b/src/Thoth.Json/Decode.fs
@@ -846,7 +846,6 @@ module Decode =
     // Reflection ///
     ////////////////
 
-    open System.Reflection
     open FSharp.Reflection
 
     type FieldType =
@@ -900,22 +899,22 @@ module Decode =
                 | Ok result -> decoder path value |> Result.map (fun v -> v::result))
 
     let rec private makeUnion t isCamelCase name (path : string) (values: obj[]) =
-        // The flags don't do anything in Fable, but we added for symmetry with .NET decoders
-        match FSharpType.GetUnionCases(t, BindingFlags.Public ||| BindingFlags.NonPublic) |> Array.tryFind (fun x -> x.Name = name) with
+        // We don't need allowAccessToPrivateRepresentation in Fable, but we add it for symmetry with .NET decoders
+        match FSharpType.GetUnionCases(t, allowAccessToPrivateRepresentation=true) |> Array.tryFind (fun x -> x.Name = name) with
         | None -> (path, FailMessage("Cannot find case " + name + " in " + t.FullName)) |> Error
         | Some uci ->
             if values.Length = 0 then
-                FSharpValue.MakeUnion(uci, [||], BindingFlags.Public ||| BindingFlags.NonPublic) |> Ok
+                FSharpValue.MakeUnion(uci, [||], allowAccessToPrivateRepresentation=true) |> Ok
             else
                 let decoders = uci.GetFields() |> Array.map (fun fi -> autoDecoder isCamelCase false fi.PropertyType)
                 mixedArray "union fields" decoders path values
-                |> Result.map (fun values -> FSharpValue.MakeUnion(uci, List.toArray values, BindingFlags.Public ||| BindingFlags.NonPublic))
+                |> Result.map (fun values -> FSharpValue.MakeUnion(uci, List.toArray values, allowAccessToPrivateRepresentation=true))
 
     and private autoDecodeRecordsAndUnions (t: System.Type) (isCamelCase : bool) (isOptional : bool) : BoxedDecoder =
-        if FSharpType.IsRecord(t, BindingFlags.Public ||| BindingFlags.NonPublic) then
+        if FSharpType.IsRecord(t, allowAccessToPrivateRepresentation=true) then
             fun path value ->
                 let decoders =
-                    FSharpType.GetRecordFields(t, BindingFlags.Public ||| BindingFlags.NonPublic)
+                    FSharpType.GetRecordFields(t, allowAccessToPrivateRepresentation=true)
                     |> Array.map (fun fi ->
                         let name =
                             if isCamelCase then
@@ -935,9 +934,9 @@ module Decode =
 
                         fieldType, name, autoDecoder isCamelCase fieldType.ToBool propertyType)
                 autoObject decoders path value
-                |> Result.map (fun xs -> FSharpValue.MakeRecord(t, List.toArray xs, BindingFlags.Public ||| BindingFlags.NonPublic))
+                |> Result.map (fun xs -> FSharpValue.MakeRecord(t, List.toArray xs, allowAccessToPrivateRepresentation=true))
 
-        elif FSharpType.IsUnion(t, BindingFlags.NonPublic) then
+        elif FSharpType.IsUnion(t, allowAccessToPrivateRepresentation=true) then
             fun path (value: obj) ->
                 if Helpers.isString(value) then
                     let name = Helpers.asString value

--- a/tests/Tests.Json.Decode.fs
+++ b/tests/Tests.Json.Decode.fs
@@ -2224,5 +2224,14 @@ I run into a `fail` decoder: Class types cannot be automatically deserialized: T
                 let json = """[ "Baz", ["Bar", "foo"]]"""
                 Decode.Auto.fromString<UnionWithPrivateConstructor list>(json, isCamelCase=true)
                 |> equal (Ok [Baz; Bar "foo"])
+
+            #if !FABLE_COMPILER
+            testCase "Newtonsoft.Json converter works with camelCased json objects" <| fun _ ->
+                let json = """{ "id" : 0, "name": "maxime", "email": "mail@domain.com", "followers": 0 }"""
+                let settings = Newtonsoft.Json.JsonSerializerSettings(Converters=Converters.All)
+                settings.ContractResolver <-  Newtonsoft.Json.Serialization.CamelCasePropertyNamesContractResolver()
+                Newtonsoft.Json.JsonConvert.DeserializeObject<_>(json, settings)
+                |> equal ({ Id = 0; Name = "maxime"; Email = "mail@domain.com"; Followers = 0 }: User)
+            #endif
         ]
     ]

--- a/tests/Tests.Json.Encode.fs
+++ b/tests/Tests.Json.Encode.fs
@@ -27,6 +27,9 @@ type SmallRecord =
             "fieldA", Encode.string x.fieldA
         ]
 
+type RecordWithPrivateConstructor = private { Foo1: int; Foo2: float }
+type UnionWithPrivateConstructor = private Bar of string | Baz
+
 let tests : Test =
     testList "Thoth.Json.Encode" [
 
@@ -353,6 +356,17 @@ let tests : Test =
                 let actual = Encode.Auto.toString(0, value, true)
                 equal expected actual
 
+            testCase "Auto.toString works with records with private constructors" <| fun _ ->
+                let expected = """{"foo1":5,"foo2":7.8}"""
+                let value = { Foo1 = 5; Foo2 = 7.8 }: RecordWithPrivateConstructor
+                let actual = Encode.Auto.toString(0, value, forceCamelCase=true)
+                equal expected actual
+
+            testCase "Auto.toString works with unions with private constructors" <| fun _ ->
+                let expected = """["Baz",["Bar","foo"]]"""
+                let value = [Baz; Bar "foo"]: UnionWithPrivateConstructor list
+                let actual = Encode.Auto.toString(0, value, forceCamelCase=true)
+                equal expected actual
         ]
 
     ]


### PR DESCRIPTION
EDIT: Please do not merge yet, I'll try to find a way so we don't need to sacrifice the CacheConverter (this can affect performance).

I should have added more tests in the previous PR... ;)

Also, I realized there's an overload for F# reflection methods with the `allowAccessToPrivateRepresetation` flag which has the same effect and makes the meaning more obvious. So I'm using it now instead of the BindingFlags.