### PR TITLE
Update Toast to Elmish 3

### DIFF
--- a/.paket/Paket.Restore.targets
+++ b/.paket/Paket.Restore.targets
@@ -17,23 +17,43 @@
     <PaketExeImage Condition=" '$(PaketBootstrapperStyle)' == 'proj' ">native</PaketExeImage>
     <MonoPath Condition="'$(MonoPath)' == '' And Exists('/Library/Frameworks/Mono.framework/Commands/mono')">/Library/Frameworks/Mono.framework/Commands/mono</MonoPath>
     <MonoPath Condition="'$(MonoPath)' == ''">mono</MonoPath>
-    <!-- Paket command -->
-    <PaketExePath Condition=" '$(PaketExePath)' == '' AND Exists('$(PaketToolsPath)paket')">$(PaketToolsPath)paket</PaketExePath>
-    <PaketExePath Condition=" '$(PaketExePath)' == '' AND Exists('$(PaketRootPath)paket.exe')">$(PaketRootPath)paket.exe</PaketExePath>
 
-    <PaketExePath Condition=" '$(PaketExePath)' == '' AND '$(OS)' == 'Windows_NT' ">$(PaketToolsPath)paket.exe</PaketExePath>
-    <PaketExePath Condition=" '$(PaketExePath)' == '' AND '$(OS)' != 'Windows_NT' AND '$(PaketExeImage)' == 'assembly' ">$(PaketToolsPath)paket.exe</PaketExePath>
-    <PaketExePath Condition=" '$(PaketExePath)' == '' AND '$(OS)' != 'Windows_NT' AND '$(PaketExeImage)' == 'native' ">$(PaketToolsPath)paket</PaketExePath>
+    <!-- PaketBootStrapper  -->
+    <PaketBootStrapperExePath Condition=" '$(PaketBootStrapperExePath)' == '' AND Exists('$(PaketRootPath)paket.bootstrapper.exe')">$(PaketRootPath)paket.bootstrapper.exe</PaketBootStrapperExePath>
+    <PaketBootStrapperExePath Condition=" '$(PaketBootStrapperExePath)' == '' ">$(PaketToolsPath)paket.bootstrapper.exe</PaketBootStrapperExePath>
+    <PaketBootStrapperExeDir Condition=" Exists('$(PaketBootStrapperExePath)') " >$([System.IO.Path]::GetDirectoryName("$(PaketBootStrapperExePath)"))\</PaketBootStrapperExeDir>
+
+    <!-- Paket -->
+
+    <!-- windows, root => tool => proj style => bootstrapper => global -->
+    <PaketExePath Condition=" '$(PaketExePath)' == '' AND '$(OS)' == 'Windows_NT' AND Exists('$(PaketRootPath)paket.exe') ">$(PaketRootPath)paket.exe</PaketExePath>
+    <PaketExePath Condition=" '$(PaketExePath)' == '' AND '$(OS)' == 'Windows_NT' AND Exists('$(PaketToolsPath)paket.exe') ">$(PaketToolsPath)paket.exe</PaketExePath>
+    <PaketExePath Condition=" '$(PaketExePath)' == '' AND '$(OS)' == 'Windows_NT' AND '$(PaketBootstrapperStyle)' == 'proj' ">$(PaketToolsPath)paket.exe</PaketExePath>
+    <PaketExePath Condition=" '$(PaketExePath)' == '' AND '$(OS)' == 'Windows_NT' AND Exists('$(PaketBootStrapperExeDir)') ">$(_PaketBootStrapperExeDir)paket.exe</PaketExePath>
+    <PaketExePath Condition=" '$(PaketExePath)' == '' AND '$(OS)' == 'Windows_NT' ">paket.exe</PaketExePath>
+
+    <!-- no windows, try native paket as default,  root => tool => proj style => mono paket => bootstrpper => global -->
+    <PaketExePath Condition=" '$(PaketExePath)' == '' AND '$(OS)' != 'Windows_NT' AND Exists('$(PaketRootPath)paket') ">$(PaketRootPath)paket</PaketExePath>
+    <PaketExePath Condition=" '$(PaketExePath)' == '' AND '$(OS)' != 'Windows_NT' AND Exists('$(PaketToolsPath)paket') ">$(PaketToolsPath)paket</PaketExePath>
+    <PaketExePath Condition=" '$(PaketExePath)' == '' AND '$(OS)' != 'Windows_NT' AND '$(PaketBootstrapperStyle)' == 'proj' ">$(PaketToolsPath)paket</PaketExePath>
+
+    <!-- no windows, try mono paket -->
+    <PaketExePath Condition=" '$(PaketExePath)' == '' AND '$(OS)' != 'Windows_NT' AND Exists('$(PaketRootPath)paket.exe') ">$(PaketRootPath)paket.exe</PaketExePath>
+    <PaketExePath Condition=" '$(PaketExePath)' == '' AND '$(OS)' != 'Windows_NT' AND Exists('$(PaketToolsPath)paket.exe') ">$(PaketToolsPath)paket.exe</PaketExePath>
+
+    <!-- no windows, try bootstrapper -->
+    <PaketExePath Condition=" '$(PaketExePath)' == '' AND '$(OS)' != 'Windows_NT' AND Exists('$(PaketBootStrapperExeDir)') ">$(PaketBootStrapperExeDir)paket.exe</PaketExePath>
+
+    <!-- no windows, try global native paket -->
+    <PaketExePath Condition=" '$(PaketExePath)' == '' AND '$(OS)' != 'Windows_NT' ">paket</PaketExePath>
 
     <!-- Paket command -->
     <_PaketExeExtension>$([System.IO.Path]::GetExtension("$(PaketExePath)"))</_PaketExeExtension>
     <PaketCommand Condition=" '$(PaketCommand)' == '' AND '$(_PaketExeExtension)' == '.dll' ">dotnet "$(PaketExePath)"</PaketCommand>
-    <PaketCommand Condition=" '$(PaketCommand)' == '' AND '$(OS)' == 'Windows_NT'">"$(PaketExePath)"</PaketCommand>
     <PaketCommand Condition=" '$(PaketCommand)' == '' AND '$(OS)' != 'Windows_NT' AND '$(_PaketExeExtension)' == '.exe' ">$(MonoPath) --runtime=v4.0.30319 "$(PaketExePath)"</PaketCommand>
-    <PaketCommand Condition=" '$(PaketCommand)' == '' AND '$(OS)' != 'Windows_NT'">"$(PaketExePath)"</PaketCommand>
+    <PaketCommand Condition=" '$(PaketCommand)' == '' ">"$(PaketExePath)"</PaketCommand>
 
-    <PaketBootStrapperExePath Condition=" '$(PaketBootStrapperExePath)' == '' AND Exists('$(PaketRootPath)paket.bootstrapper.exe')">$(PaketRootPath)paket.bootstrapper.exe</PaketBootStrapperExePath>
-    <PaketBootStrapperExePath Condition=" '$(PaketBootStrapperExePath)' == '' ">$(PaketToolsPath)paket.bootstrapper.exe</PaketBootStrapperExePath>
+
     <PaketBootStrapperCommand Condition=" '$(OS)' == 'Windows_NT'">"$(PaketBootStrapperExePath)"</PaketBootStrapperCommand>
     <PaketBootStrapperCommand Condition=" '$(OS)' != 'Windows_NT' ">$(MonoPath) --runtime=v4.0.30319 "$(PaketBootStrapperExePath)"</PaketBootStrapperCommand>
 

--- a/paket.dependencies
+++ b/paket.dependencies
@@ -8,7 +8,7 @@ nuget FSharp.Core redirects:force
 nuget Fable.Import.Browser
 nuget Newtonsoft.Json >= 11.0.2
 nuget Expecto
-nuget Fable.Elmish
+nuget Fable.Elmish prerelease
 nuget Fable.PowerPack
 nuget Fable.React
 nuget Fable.Import.HMR

--- a/paket.lock
+++ b/paket.lock
@@ -17,12 +17,12 @@ NUGET
       Argu (>= 5.1) - restriction: || (>= net461) (>= netstandard2.0)
       Mono.Cecil (>= 0.10) - restriction: || (>= net461) (>= netstandard2.0)
       System.Diagnostics.FileVersionInfo (>= 4.3) - restriction: && (< net461) (>= netstandard2.0)
-    Fable.Core (2.0)
+    Fable.Core (2.0.2)
       FSharp.Core (>= 4.5.2) - restriction: >= netstandard2.0
-    Fable.Elmish (2.0)
-      Fable.Core (>= 2.0) - restriction: >= netstandard2.0
-      Fable.PowerPack (>= 2.0.1) - restriction: >= netstandard2.0
-      FSharp.Core (>= 4.5.2) - restriction: >= netstandard2.0
+    Fable.Elmish (3.0.0-beta-4)
+      Fable.Core (>= 2.0.2) - restriction: >= netstandard2.0
+      Fable.Promise (>= 1.0) - restriction: >= netstandard2.0
+      FSharp.Core (>= 4.5.4) - restriction: >= netstandard2.0
     Fable.Import.Browser (1.3)
       Fable.Core (>= 1.3.17) - restriction: >= netstandard1.6
     Fable.Import.HMR (0.1)
@@ -32,6 +32,9 @@ NUGET
       Fable.Import.Browser (>= 1.3) - restriction: >= netstandard2.0
       FSharp.Core (>= 4.5.2) - restriction: >= netstandard2.0
       Thoth.Json (>= 2.0) - restriction: >= netstandard2.0
+    Fable.Promise (1.0) - restriction: >= netstandard2.0
+      Fable.Core (>= 2.0.2) - restriction: >= netstandard2.0
+      FSharp.Core (>= 4.5.2) - restriction: >= netstandard2.0
     Fable.React (4.1.3)
       Fable.Core (>= 2.0) - restriction: >= netstandard2.0
       Fable.Import.Browser (>= 1.3) - restriction: >= netstandard2.0
@@ -46,7 +49,7 @@ NUGET
       System.Reflection.TypeExtensions (>= 4.3) - restriction: && (< net45) (>= netstandard2.0)
       System.Runtime.Loader (>= 4.0) - restriction: && (< net45) (>= netstandard2.0)
       System.Security.Cryptography.Algorithms (>= 4.3) - restriction: && (< net45) (>= netstandard2.0)
-    FSharp.Core (4.5.2) - redirects: force
+    FSharp.Core (4.5.4) - redirects: force
       System.Collections (>= 4.0.11) - restriction: && (< net45) (>= netstandard1.6) (< netstandard2.0)
       System.Console (>= 4.0) - restriction: && (< net45) (>= netstandard1.6) (< netstandard2.0)
       System.Diagnostics.Debug (>= 4.0.11) - restriction: && (< net45) (>= netstandard1.6) (< netstandard2.0)

--- a/src/Thoth.Elmish.Toast/Toast.fs
+++ b/src/Thoth.Elmish.Toast/Toast.fs
@@ -440,7 +440,15 @@ module Toast =
               view = fun model dispatch ->
                 div [ ]
                     [ view renderer model dispatch
-                      program.view model.UserModel (UserMsg >> dispatch) ] }
+                      program.view model.UserModel (UserMsg >> dispatch) ]
+              syncDispatch = fun dispatch ->
+                    let syncDispatch = program.syncDispatch (UserMsg >> dispatch)
+                    fun msg ->
+                        match msg with
+                        | UserMsg msg -> syncDispatch msg
+                        // REVIEW: Not sure what to do here, do we need syncDispatch for Toast messages?
+                        // As syncDispatch is meant for .NET maybe we don't need it at all: `syncDispatch = id`
+                        | msg -> dispatch msg }
 
     /// **Description**
     /// Default implementation for the Toast renderer,

--- a/src/Thoth.Elmish.Toast/Toast.fs
+++ b/src/Thoth.Elmish.Toast/Toast.fs
@@ -440,14 +440,8 @@ module Toast =
                 div [ ]
                     [ view renderer model dispatch
                       program.view model.UserModel (UserMsg >> dispatch) ]
-              syncDispatch = fun dispatch ->
-                    let syncDispatch = program.syncDispatch (UserMsg >> dispatch)
-                    fun msg ->
-                        match msg with
-                        | UserMsg msg -> syncDispatch msg
-                        // REVIEW: Not sure what to do here, do we need syncDispatch for Toast messages?
-                        // As syncDispatch is meant for .NET maybe we don't need it at all: `syncDispatch = id`
-                        | msg -> dispatch msg }
+              // syncDispatch is only intended for .NET
+              syncDispatch = id }
 
     /// **Description**
     /// Default implementation for the Toast renderer,

--- a/src/Thoth.Elmish.Toast/Toast.fs
+++ b/src/Thoth.Elmish.Toast/Toast.fs
@@ -8,7 +8,6 @@ module Toast =
     open Fable.Helpers.React.Props
     open Elmish
     open Fable.Core.JsInterop
-    open Fable.PowerPack
 
     importSideEffects "./css/toast-base.css"
     importSideEffects "./css/toast-minimal.css"

--- a/src/Thoth.Elmish.Toast/paket.references
+++ b/src/Thoth.Elmish.Toast/paket.references
@@ -2,6 +2,5 @@ FSharp.Core
 Fable.Core
 dotnet-fable
 Fable.Elmish
-Fable.PowerPack
 Fable.React
 Fable.Import.HMR


### PR DESCRIPTION
Fix #100. At the end I didn't change `Cmd.ofPromise` because Elmish 3 will have a dependency on Fable.Promise anyways. However, I'm not sure what to do with `syncDispatch`. This is a partial implementation, it doesn't work for Toast messages. However, if `syncDispatch` is only intended for .NET maybe we can just use `syncDispatch = id`. Can you please confirm this @et1975? (If that's the case, it may be worth to add a comment doc to the field explaining it.)