### PR TITLE
Don't inject variables in production mode

### DIFF
--- a/src/Thoth.Elmish.Toast/Toast.fs
+++ b/src/Thoth.Elmish.Toast/Toast.fs
@@ -402,11 +402,12 @@ module Toast =
                   Toasts_TC = []
                   Toasts_TR = [] }, cmd
 
-            let notifcationEvent (dispatch : Elmish.Dispatch<Notifiable<_, _>>) =
+            let notificationEvent (dispatch : Elmish.Dispatch<Notifiable<_, _>>) =
                 // If HMR support is active, then we provide have a custom implementation.
                 // This is needed to avoid:
                 // - flickering (trigger several react renderer process)
                 // - attaching several event listener to the same event
+                #if DEBUG
                 if not (isNull HMR.``module``.hot) then
                     if HMR.``module``.hot.status() <> HMR.Idle then
                         Browser.window.removeEventListener(eventIdentifier, !!Browser.window?(eventIdentifier))
@@ -417,6 +418,7 @@ module Toast =
 
                     Browser.window.addEventListener(eventIdentifier, !!Browser.window?(eventIdentifier))
                 else
+                #endif
                     Browser.window.addEventListener(eventIdentifier, !^(fun ev ->
                         let ev = ev :?> Browser.CustomEvent
                         dispatch (Add (unbox ev.detail))
@@ -428,7 +430,7 @@ module Toast =
                             model, cmd |> Cmd.map UserMsg) >> createModel
 
             let subs model =
-                Cmd.batch [ [ notifcationEvent ]
+                Cmd.batch [ [ notificationEvent ]
                             program.subscribe model.UserModel |> Cmd.map UserMsg ]
 
             { init = init


### PR DESCRIPTION
As commented [here](https://github.com/SAFE-Stack/SAFE-template/issues/185#issuecomment-445765771) injecting global variables breaks module concatenation in Webpack. Using the compilation directive we can save around 40KB in the production bundle.