### PR TITLE
Throw error when using ITypeResolver from .NET

### DIFF
--- a/src/Thoth.Json.Net/Decode.fs
+++ b/src/Thoth.Json.Net/Decode.fs
@@ -1034,7 +1034,7 @@ module Decode =
         static member generateDecoderCached<'T> (?isCamelCase : bool, ?extra: ExtraCoders): Decoder<'T> =
             let t = typeof<'T>
             let decoderCrate =
-                Cache.Decoders.Value.GetOrAdd(t, fun t ->
+                Util.CachedDecoders.Value.GetOrAdd(t, fun t ->
                     let isCamelCase = defaultArg isCamelCase false
                     let extra = match extra with Some e -> e | None -> Map.empty
                     autoDecoder extra isCamelCase false t)

--- a/src/Thoth.Json.Net/Encode.fs
+++ b/src/Thoth.Json.Net/Encode.fs
@@ -457,7 +457,7 @@ module Encode =
     type Auto =
         /// ATTENTION: Use this only when other arguments (isCamelCase, extra) don't change
         static member generateEncoderCached(t: System.Type, ?isCamelCase : bool, ?extra: ExtraCoders): Encoder<obj> =
-            Cache.Encoders.Value.GetOrAdd(t, fun t ->
+            Util.CachedEncoders.Value.GetOrAdd(t, fun t ->
                 let isCamelCase = defaultArg isCamelCase false
                 let extra = match extra with Some e -> e | None -> Map.empty
                 autoEncoder extra isCamelCase t).BoxedEncoder
@@ -465,7 +465,7 @@ module Encode =
         static member generateEncoderCached<'T>(?isCamelCase : bool, ?extra: ExtraCoders): Encoder<'T> =
             let t = typeof<'T>
             let encoderCrate =
-                Cache.Encoders.Value.GetOrAdd(t, fun t ->
+                Util.CachedEncoders.Value.GetOrAdd(t, fun t ->
                     let isCamelCase = defaultArg isCamelCase false
                     let extra = match extra with Some e -> e | None -> Map.empty
                     autoEncoder extra isCamelCase t)

--- a/src/Thoth.Json.Net/Types.fs
+++ b/src/Thoth.Json.Net/Types.fs
@@ -31,7 +31,7 @@ type BoxedEncoder() =
 
 type ExtraCoders = Map<string, BoxedEncoder * BoxedDecoder>
 
-module internal Cache =
+module internal Util =
     open System
     open System.Collections.Concurrent
 
@@ -40,5 +40,5 @@ module internal Cache =
         member __.GetOrAdd(key: 'Key, factory: 'Key->'Value) =
             cache.GetOrAdd(key, factory)
 
-    let Encoders = lazy Cache<Type, BoxedEncoder>()
-    let Decoders = lazy Cache<Type, BoxedDecoder>()
+    let CachedEncoders = lazy Cache<Type, BoxedEncoder>()
+    let CachedDecoders = lazy Cache<Type, BoxedDecoder>()

--- a/src/Thoth.Json/Decode.fs
+++ b/src/Thoth.Json/Decode.fs
@@ -951,7 +951,7 @@ module Decode =
             elif fullname = typeof<System.DateTimeOffset>.FullName then
                 boxDecoder datetimeOffset
             elif fullname = typeof<System.TimeSpan>.FullName then
-                boxDecoder timespan                
+                boxDecoder timespan
             elif fullname = typeof<System.Guid>.FullName then
                 boxDecoder guid
             elif fullname = typeof<obj>.FullName then
@@ -961,8 +961,8 @@ module Decode =
     type Auto =
         /// ATTENTION: Use this only when other arguments (isCamelCase, extra) don't change
         static member generateDecoderCached<'T>(?isCamelCase : bool, ?extra: ExtraCoders, [<Inject>] ?resolver: ITypeResolver<'T>): Decoder<'T> =
-            let t = resolver.Value.ResolveType()
-            Cache.Decoders.GetOrAdd(t.FullName, fun _ ->
+            let t = Util.resolveType resolver
+            Util.CachedDecoders.GetOrAdd(t.FullName, fun _ ->
                 let isCamelCase = defaultArg isCamelCase false
                 let extra = match extra with Some e -> e | None -> Map.empty
                 autoDecoder extra isCamelCase false t) |> unboxDecoder
@@ -970,7 +970,7 @@ module Decode =
         static member generateDecoder<'T>(?isCamelCase : bool, ?extra: ExtraCoders, [<Inject>] ?resolver: ITypeResolver<'T>): Decoder<'T> =
             let isCamelCase = defaultArg isCamelCase false
             let extra = match extra with Some e -> e | None -> Map.empty
-            resolver.Value.ResolveType() |> autoDecoder extra isCamelCase false |> unboxDecoder
+            Util.resolveType resolver |> autoDecoder extra isCamelCase false |> unboxDecoder
 
         static member fromString<'T>(json: string, ?isCamelCase : bool, ?extra: ExtraCoders, [<Inject>] ?resolver: ITypeResolver<'T>): Result<'T, string> =
             let decoder = Auto.generateDecoder(?isCamelCase=isCamelCase, ?extra=extra, ?resolver=resolver)

--- a/src/Thoth.Json/Encode.fs
+++ b/src/Thoth.Json/Encode.fs
@@ -456,8 +456,8 @@ module Encode =
     type Auto =
         /// ATTENTION: Use this only when other arguments (isCamelCase, extra) don't change
         static member generateEncoderCached<'T>(?isCamelCase : bool, ?extra: ExtraCoders, [<Inject>] ?resolver: ITypeResolver<'T>): Encoder<'T> =
-            let t = resolver.Value.ResolveType()
-            Cache.Encoders.GetOrAdd(t.FullName, fun _ ->
+            let t = Util.resolveType resolver
+            Util.CachedEncoders.GetOrAdd(t.FullName, fun _ ->
                 let isCamelCase = defaultArg isCamelCase false
                 let extra = match extra with Some e -> e | None -> Map.empty
                 autoEncoder extra isCamelCase t) |> unboxEncoder
@@ -465,7 +465,7 @@ module Encode =
         static member generateEncoder<'T>(?isCamelCase : bool, ?extra: ExtraCoders, [<Inject>] ?resolver: ITypeResolver<'T>): Encoder<'T> =
             let isCamelCase = defaultArg isCamelCase false
             let extra = match extra with Some e -> e | None -> Map.empty
-            resolver.Value.ResolveType() |> autoEncoder extra isCamelCase |> unboxEncoder
+            Util.resolveType resolver |> autoEncoder extra isCamelCase |> unboxEncoder
 
         static member toString(space : int, value : 'T, ?isCamelCase : bool, ?extra: ExtraCoders, [<Inject>] ?resolver: ITypeResolver<'T>) : string =
             let encoder = Auto.generateEncoder(?isCamelCase=isCamelCase, ?extra=extra, ?resolver=resolver)

--- a/src/Thoth.Json/Types.fs
+++ b/src/Thoth.Json/Types.fs
@@ -24,7 +24,7 @@ type BoxedEncoder = Encoder<obj>
 
 type ExtraCoders = Map<string, BoxedEncoder * BoxedDecoder>
 
-module internal Cache =
+module internal Util =
     open System.Collections.Generic
 
     type Cache<'Value>() =
@@ -39,5 +39,14 @@ module internal Cache =
 
     // Tree shaking will remove this if not used
     // so no need to make them lazy in Fable
-    let Encoders = Cache<BoxedEncoder>()
-    let Decoders = Cache<BoxedDecoder>()
+    let CachedEncoders = Cache<BoxedEncoder>()
+    let CachedDecoders = Cache<BoxedDecoder>()
+
+    /// If used from .NET the type resolver won't be injected,
+    /// throw a more informative error than just a null reference.
+    let inline resolveType (resolver: Fable.Core.ITypeResolver<'T> option): System.Type =
+#if !FABLE_COMPILER
+        failwith "Thoth.Json is only compatible with Fable, use Thoth.Json.Net"
+#else
+        resolver.Value.ResolveType()
+#endif


### PR DESCRIPTION
Related to #124. I've found that the null reference exception comes when accessing the type resolver value. This is not injected in .NET so the value is empty and the error happens. I've made it so a more informative error is thrown. In other cases (when not using auto coders) a `JS only` error is thrown, this should give a hint to users (hopefully).