### PR TITLE
Adding a link to jason-to-thoth tool

### DIFF
--- a/docs/src/Content/Json/v2.md
+++ b/docs/src/Content/Json/v2.md
@@ -341,3 +341,7 @@ type User =
               "followers", Encode.int user.Followers
             ]
 ```
+
+## Online tool
+
+Convert a JSON snippet to F# record with Decoders using [JSON to Thoth](https://nojaf.com/redhood/).


### PR DESCRIPTION
I've added it only for v2 since v3 is not tested/supported.